### PR TITLE
fix: "やす" は ですます調の判定から除外する

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+changelog:
+  exclude:
+    labels:
+      - 'Type: Meta'
+      - 'Type: Question'
+      - 'Type: Release'
+
+  categories:
+    - title: Security Fixes
+      labels: ['Type: Security']
+    - title: Breaking Changes
+      labels: ['Type: Breaking Change']
+    - title: Features
+      labels: ['Type: Feature']
+    - title: Bug Fixes
+      labels: ['Type: Bug']
+    - title: Documentation
+      labels: ['Type: Documentation']
+    - title: Refactoring
+      labels: ['Type: Refactoring']
+    - title: Testing
+      labels: ['Type: Testing']
+    - title: Maintenance
+      labels: ['Type: Maintenance']
+    - title: CI
+      labels: ['Type: CI']
+    - title: Dependency Updates
+      labels: ['Type: Dependencies', "dependencies"]
+    - title: Other Changes
+      labels: ['*']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14]
+        node-version: [ 20, 22 ]
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/package.json
+++ b/package.json
@@ -57,5 +57,6 @@
     "*.{js,jsx,ts,tsx,css}": [
       "prettier --write"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca"
 }

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -50,11 +50,16 @@ export function isDearu({ type }) {
 }
 
 /**
- * typeが敬体(ですます調)か常体(である調)かを判定する
+ * typeが敬体(ですます調)なら true を返す
  * @param {string} type
  * @returns {boolean}
  */
 const isDesumasuType = (type) => type === Types.desu || type === Types.masu;
+/**
+ * typeが常体(である調)なら true を返す
+ * @param type
+ * @returns {boolean}
+ */
 const isDearuType = (type) => type === Types.dearu;
 
 /**
@@ -122,8 +127,7 @@ const mapToAnalyzedResult = (tokens) => {
         return {
             type: token["conjugated_type"],
             value: value,
-            surface: token["surface_form"],
-            // index start with 0
+            surface: token["surface_form"], // index start with 0
             index: token["word_position"] - 1,
             /**
              * @type {AnalyzedToken}
@@ -160,6 +164,12 @@ export function analyze(text, options = defaultOptions) {
                     }
                 }
             } else if (isDesumasuType(conjugatedType)) {
+                // "やす" は "特殊・マス" として認識されるが、誤判定を避けるために除外する
+                // https://github.com/textlint-ja/textlint-rule-no-mix-dearu-desumasu/issues/52
+                if (token["basic_form"] === "やす") {
+                    return false;
+                }
+
                 // TODO: can omit?
                 if (token["conjugated_form"] === "基本形") {
                     // 文末の"です"のみを許容する場合は、文末であるかどうかを調べる

--- a/test/analyze-test.js
+++ b/test/analyze-test.js
@@ -139,6 +139,12 @@ describe("analyze-test", function () {
                     });
                 });
             });
+            it("'やす'はですます調としては認識しない", function () {
+                let text = "構成物の崩れやすさ、脆さに注意が必要である。";
+                return analyzeDesumasu(text).then((results) => {
+                    assert(results.length === 0);
+                });
+            });
         });
     });
     describe("analyzeDearu", function () {


### PR DESCRIPTION
> 構成物の崩れやすさ、脆さに注意が必要である。

```
echo "構成物の崩れやすさ、脆さに注意が必要である。" | mecab
構成    名詞,サ変接続,*,*,*,*,構成,コウセイ,コーセイ
物      名詞,接尾,一般,*,*,*,物,ブツ,ブツ
の      助詞,連体化,*,*,*,*,の,ノ,ノ
崩れ    動詞,自立,*,*,一段,連用形,崩れる,クズレ,クズレ
やす    助動詞,*,*,*,特殊・マス,基本形,やす,ヤス,ヤス
さ      助詞,終助詞,*,*,*,*,さ,サ,サ
、      記号,読点,*,*,*,*,、,、,、
脆      形容詞,自立,*,*,形容詞・アウオ段,ガル接続,脆い,モロ,モロ
さ      名詞,接尾,特殊,*,*,*,さ,サ,サ
に      助詞,格助詞,一般,*,*,*,に,ニ,ニ
注意    名詞,サ変接続,*,*,*,*,注意,チュウイ,チューイ
が      助詞,格助詞,一般,*,*,*,が,ガ,ガ
必要    名詞,形容動詞語幹,*,*,*,*,必要,ヒツヨウ,ヒツヨー
で      助動詞,*,*,*,特殊・ダ,連用形,だ,デ,デ
ある    助動詞,*,*,*,五段・ラ行アル,基本形,ある,アル,アル
。      記号,句点,*,*,*,*,。,。,。
EOS
```

"やす"が"特殊・マス"として解析されてるので、ですます調として認識されてしまっていた。
あまり意図した挙動ではないので、"やす"は除外する

"やす"は"です"の訛りとして扱われている可能性がある? 
訛りはライブラリとしてはカバーできない

fix https://github.com/textlint-ja/textlint-rule-no-mix-dearu-desumasu/issues/52